### PR TITLE
Add support for Boolean.FalseString,Boolean.TrueString, Boolean.Parse, and Boolean.TryParse

### DIFF
--- a/Bridge/Bridge.csproj
+++ b/Bridge/Bridge.csproj
@@ -602,6 +602,7 @@
     <EmbeddedResource Include="Resources\Locales\zh.js" />
     <EmbeddedResource Include="Resources\Locales\zu-ZA.js" />
     <EmbeddedResource Include="Resources\Locales\zu.js" />
+    <Content Include="Resources\Boolean.js" />
     <Content Include="Resources\Version.js" />
     <None Include="AdditionalCompilerOptions.txt" />
     <Content Include="Resources\Array.js" />

--- a/Bridge/Resources/Boolean.js
+++ b/Bridge/Resources/Boolean.js
@@ -1,0 +1,36 @@
+﻿// @source Boolean.js
+
+Bridge.define('Bridge.Boolean', {
+    statics: {
+        parse: function (str) {
+            if (str == null) {
+                throw new Bridge.ArgumentNullException("str");
+            }
+
+            if (/^\s*false\s*$/i.test(str)) {
+                return false;
+            }
+
+            if (/^\s*true\s*$/i.test(str)) {
+                return true;
+            }
+
+            throw new Bridge.FormatException("Input string was not in a correct format.");            
+        },
+
+        tryParse: function (str, result) {
+            result.v = false;
+
+            if (/^\s*false\s*$/i.test(str)) {
+                result.v = false;
+                return true;
+            }
+            else if (/^\s*true\s*$/i.test(str)) {
+                result.v = true;
+                return true;
+            }
+
+            return false;
+        },
+    }
+});

--- a/Bridge/Resources/Bridge.jsb
+++ b/Bridge/Resources/Bridge.jsb
@@ -31,6 +31,7 @@
   <file name="INotifyPropertyChanged.js" />
   <file name="Array.js" />
   <file name="linq.js" />
+  <file name="Boolean.js" />
   <target name="Bridge.NET" file="$output\bridge.js" debug="True">
     <include name="Init.js" />
     <include name="Core.js" />
@@ -62,6 +63,7 @@
     <include name="INotifyPropertyChanged.js" />
     <include name="Array.js" />
     <include name="linq.js" />
+    <include name="Boolean.js" />
     <include name="End.js" />
   </target>
 </project>

--- a/Bridge/System/Boolean.cs
+++ b/Bridge/System/Boolean.cs
@@ -11,5 +11,23 @@ namespace System
         public Boolean(object value)
         {
         }
+
+        public static string FalseString
+        {
+            [Template("'False'")]
+            get { return string.Empty; }
+        }
+
+        public static string TrueString
+        {
+            [Template("'True'")]
+            get { return string.Empty; }
+        }
+
+        [Template("Bridge.Boolean.parse({value})")]
+        public static extern bool Parse(string value);
+
+        [Template("Bridge.Boolean.tryParse({value}, {result})")]
+        public static extern bool TryParse(string value, out bool result);
     }
 }


### PR DESCRIPTION
- Basic support for FalseString and TrueString. FalseString returns
  'False' and TrueString returns 'True'.
- Support for Parse: The value parameter, optionally preceded or trailed
  by white space, must contain either TrueString or FalseString;
  otherwise, an exception is thrown. The comparison is case-insensitive.
- Support for TryParse: like the Parse method but does not throw an
  exception on failure, instead it returns false instead of true.
